### PR TITLE
DAG-1689 Update git-co-evg-base to print helpful tuning message

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
         pip install poetry
         poetry install
 
-        wget -q https://github.com/dbradf/pypi-version-check/releases/download/v0.1.2/pypi-version-check
+        wget -q https://github.com/dbradf/pypi-version-check/releases/download/v0.3.0/pypi-version-check
         chmod +x pypi-version-check
 
     - name: Test with pytest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 0.5.14 - 2022-04-06
+- Update the message printed when no revision is found.
+
 ## 0.5.13 - 2022-04-06
 - Migrating to evergreen-ci organization in Github.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "git-co-evg-base"
-version = "0.5.13"
+version = "0.5.14"
 description = "Find a good commit to base your work on"
 authors = ["David Bradford <david.bradford@mongodb.com>"]
 readme = "README.md"

--- a/src/goodbase/goodbase_cli.py
+++ b/src/goodbase/goodbase_cli.py
@@ -492,7 +492,15 @@ def main(
                 for module, errmsg in revision.errors.items():
                     click.echo(click.style(f"\t{module}: {errmsg}", fg="yellow"))
         else:
-            click.echo(click.style("No revision found", fg="red"))
+            click.echo(
+                click.style(
+                    "No revision found\n"
+                    "For more detailed information about what command is doing, use `--verbose` option\n"
+                    "For more information about how to specify criteria, see"
+                    " https://dbradf.github.io/git-co-evg-base/concepts/criteria/",
+                    fg="red",
+                )
+            )
             sys.exit(1)
 
 

--- a/src/goodbase/goodbase_cli.py
+++ b/src/goodbase/goodbase_cli.py
@@ -492,14 +492,11 @@ def main(
                 for module, errmsg in revision.errors.items():
                     click.echo(click.style(f"\t{module}: {errmsg}", fg="yellow"))
         else:
+            click.echo(click.style("No revision found", fg="red"))
             click.echo(
-                click.style(
-                    "No revision found\n"
-                    "For more detailed information about what command is doing, use `--verbose` option\n"
-                    "For more information about how to specify criteria, see"
-                    " https://dbradf.github.io/git-co-evg-base/concepts/criteria/",
-                    fg="red",
-                )
+                "For more detailed information about what command is doing, use `--verbose` option\n"
+                "For more information about how to specify criteria, see"
+                " https://evergreen-ci.github.io/git-co-evg-base/concepts/criteria/",
             )
             sys.exit(1)
 


### PR DESCRIPTION
Example
```
$ poetry run git-co-evg-base --commit-lookback 1
Searching mongodb-mongo-master revisions  [####################################]  100%
No revision found
For more detailed information about what command is doing, use `--verbose` option
For more information about how to specify criteria, see https://dbradf.github.io/git-co-evg-base/concepts/criteria/
```