### PR TITLE
DEVPROD-7291: add an option to override the version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 7.0.2 - 2024-07-24
+- Add an option to check only one specific version with version_override
+
 ## 7.0.1 - 2024-06-11
 - Fix for unbound variable.
 - Add back support for mongo default variants

--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Options:
   --commit-lookback INTEGER       Number of commits to check before giving up.  [default: 50]
   --timeout-secs INTEGER          Number of seconds to search for before giving up.
   --commit-limit TEXT             Oldest commit to check before giving up.
+  --version_override              Select a single version to check.
   --git-operation [checkout|rebase|merge|none]
                                   Git operations to perform with found commit.  [default: none]
   -b, --branch TEXT               Name of branch to create on checkout. When specified, git-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "git-co-evg-base"
-version = "7.0.1"
+version = "7.0.2"
 description = "Find a good commit to base your work on"
 authors = ["DevProd Services & Integrations Team <devprod-si-team@mongodb.com>"]
 readme = "README.md"

--- a/src/goodbase/goodbase_cli.py
+++ b/src/goodbase/goodbase_cli.py
@@ -138,6 +138,7 @@ class GoodBaseOrchestrator:
         self,
         evg_project: str,
         build_checks: List[BuildChecks],
+        version_override: Optional[str] = None,
     ) -> Optional[RevisionInformation]:
         """
         Find the latest git revision that matches the criteria and check it out in git.
@@ -146,7 +147,7 @@ class GoodBaseOrchestrator:
         :param build_checks: Criteria to enforce.
         :return: Revision that was checked out, if it exists.
         """
-        revision = self.search_service.find_revision(evg_project, build_checks)
+        revision = self.search_service.find_revision(evg_project, build_checks, version_override)
         if revision:
             module_revisions = self.evg_service.get_modules_revisions(evg_project, revision)
             errmsg = self.attempt_git_operation(self.options.operation, revision)
@@ -289,6 +290,7 @@ def configure_logging(verbose: bool) -> None:
     default=MAX_LOOKBACK,
     help="Number of commits to check before giving up.",
 )
+@click.option("--version-override", help="A specific version to test.")
 @click.option("--timeout-secs", type=int, help="Number of seconds to search for before giving up.")
 @click.option(
     "--commit-limit",
@@ -358,6 +360,7 @@ def main(
     output_format: OutputFormat,
     override: bool,
     verbose: bool,
+    version_override: Optional[str],
 ) -> None:
     """
     Find and perform git actions on a recent commit that matches the specified criteria.
@@ -547,7 +550,7 @@ def main(
             )
             return
 
-        revision = orchestrator.checkout_good_base(evg_project, criteria)
+        revision = orchestrator.checkout_good_base(evg_project, criteria, version_override)
 
         if revision:
             revision_dict = {

--- a/src/goodbase/services/search_service.py
+++ b/src/goodbase/services/search_service.py
@@ -32,7 +32,9 @@ class SearchService:
         self.evg_service = evg_service
         self.options = options
 
-    def find_revision(self, evg_project: str, build_checks: List[BuildChecks]) -> Optional[str]:
+    def find_revision(
+        self, evg_project: str, build_checks: List[BuildChecks], version_override: Optional[str]
+    ) -> Optional[str]:
         """
         Iterate through revisions until one is found that matches the given criteria.
 
@@ -40,7 +42,11 @@ class SearchService:
         :param build_checks: Criteria to enforce.
         :return: First git revision to match the given criteria if it exists.
         """
-        versions = self.evg_api.versions_by_project(evg_project)
+        if version_override:
+            versions = [self.evg_api.version_by_id(version_override)]
+            # versions = [self.evg_api.version_by_id("mongodb_mongo_master_2b97def86f790965b512bbba1c6b88bba000aa64")]
+        else:
+            versions = self.evg_api.versions_by_project(evg_project)
 
         if self.options.output_format in {OutputFormat.YAML, OutputFormat.JSON}:
             stable_revision = self._find_stable_revision(versions, build_checks)
@@ -72,7 +78,6 @@ class SearchService:
                 return None
 
             LOGGER.debug("Checking version", commit=evg_version.revision)
-
             if self.evg_service.check_version(evg_version, build_checks):
                 return evg_version.revision
 

--- a/src/goodbase/services/search_service.py
+++ b/src/goodbase/services/search_service.py
@@ -43,7 +43,7 @@ class SearchService:
         :return: First git revision to match the given criteria if it exists.
         """
         if version_override:
-            versions = [self.evg_api.version_by_id(version_override)]
+            versions = iter([self.evg_api.version_by_id(version_override)])
             # versions = [self.evg_api.version_by_id("mongodb_mongo_master_2b97def86f790965b512bbba1c6b88bba000aa64")]
         else:
             versions = self.evg_api.versions_by_project(evg_project)

--- a/src/goodbase/services/search_service.py
+++ b/src/goodbase/services/search_service.py
@@ -44,7 +44,6 @@ class SearchService:
         """
         if version_override:
             versions = iter([self.evg_api.version_by_id(version_override)])
-            # versions = [self.evg_api.version_by_id("mongodb_mongo_master_2b97def86f790965b512bbba1c6b88bba000aa64")]
         else:
             versions = self.evg_api.versions_by_project(evg_project)
 

--- a/tests/goodbase/services/test_search_service.py
+++ b/tests/goodbase/services/test_search_service.py
@@ -52,7 +52,7 @@ class TestFindRevision:
 
         search_service._find_stable_revision = assert_progress_bar
 
-        search_service.find_revision("project", [])
+        search_service.find_revision("project", [], None)
 
     @pytest.mark.parametrize("format", [OutputFormat.YAML, OutputFormat.JSON])
     def test_find_revision_should_not_use_progressbar_for_non_plaintest(
@@ -64,7 +64,7 @@ class TestFindRevision:
         options.output_format = format
         search_service._find_stable_revision = assert_no_progress_bar
 
-        search_service.find_revision("project", [])
+        search_service.find_revision("project", [], None)
 
 
 class TestFindStableRevision:


### PR DESCRIPTION
Just added an option to override the version.

This helps when you want to know why a specific version was/n't selected. If enough time passed since the incident - that version might never be scanned to start with.