### PR TITLE
DEVPROD-6923: allow skipping known issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## 7.0.3 - 2024-07-25
+- Add an option to ignore task failures for known failures
+
 ## 7.0.2 - 2024-07-24
 - Add an option to check only one specific version with version_override
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Changelog
-## 7.0.3 - 2024-07-25
+## 7.1.0 - 2024-07-25
 - Add an option to ignore task failures for known failures
 
 ## 7.0.2 - 2024-07-24

--- a/README.md
+++ b/README.md
@@ -158,7 +158,8 @@ Options:
   --commit-lookback INTEGER       Number of commits to check before giving up.  [default: 50]
   --timeout-secs INTEGER          Number of seconds to search for before giving up.
   --commit-limit TEXT             Oldest commit to check before giving up.
-  --version_override              Select a single version to check.
+  --version-override              Select a single version to check.
+  --allow-known-failures          Allow known failures to be considered as passing.
   --git-operation [checkout|rebase|merge|none]
                                   Git operations to perform with found commit.  [default: none]
   -b, --branch TEXT               Name of branch to create on checkout. When specified, git-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "git-co-evg-base"
-version = "7.0.3"
+version = "7.1.0"
 description = "Find a good commit to base your work on"
 authors = ["DevProd Services & Integrations Team <devprod-si-team@mongodb.com>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "git-co-evg-base"
-version = "7.0.2"
+version = "7.0.3"
 description = "Find a good commit to base your work on"
 authors = ["DevProd Services & Integrations Team <devprod-si-team@mongodb.com>"]
 readme = "README.md"

--- a/src/goodbase/goodbase_cli.py
+++ b/src/goodbase/goodbase_cli.py
@@ -138,7 +138,7 @@ class GoodBaseOrchestrator:
         self,
         evg_project: str,
         build_checks: List[BuildChecks],
-        allow_known_failures: bool,
+        allow_known_failures: bool = False,
         version_override: Optional[str] = None,
     ) -> Optional[RevisionInformation]:
         """
@@ -294,7 +294,12 @@ def configure_logging(verbose: bool) -> None:
     help="Number of commits to check before giving up.",
 )
 @click.option("--version-override", help="A specific version to test.")
-@click.option("--allow-known-failures", type=bool, help="consider known failures as passing.")
+@click.option(
+    "--allow-known-failures",
+    is_flag=True,
+    default=False,
+    help="consider known failures as passing.",
+)
 @click.option("--timeout-secs", type=int, help="Number of seconds to search for before giving up.")
 @click.option(
     "--commit-limit",
@@ -364,8 +369,8 @@ def main(
     output_format: OutputFormat,
     override: bool,
     verbose: bool,
+    allow_known_failures: bool,
     version_override: Optional[str],
-    allow_known_failures: Optional[bool] = False,
 ) -> None:
     """
     Find and perform git actions on a recent commit that matches the specified criteria.

--- a/src/goodbase/goodbase_cli.py
+++ b/src/goodbase/goodbase_cli.py
@@ -146,6 +146,7 @@ class GoodBaseOrchestrator:
 
         :param evg_project: Evergreen project to check.
         :param build_checks: Criteria to enforce.
+        :param allow_known_failures: Whether to allow known failures as passing ones.
         :return: Revision that was checked out, if it exists.
         """
         revision = self.search_service.find_revision(

--- a/src/goodbase/services/evg_service.py
+++ b/src/goodbase/services/evg_service.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Optional
 import inject
 import structlog
 import yaml
-from evergreen import Build, EvergreenApi, Version
+from evergreen import Build, EvergreenApi, Version, Task
 from requests.exceptions import HTTPError
 
 from goodbase.build_checker import BuildChecks
@@ -64,7 +64,7 @@ class EvergreenService:
             all_tasks=all_tasks,
         )
 
-    def _get_successful_tasks(self, tasks, allow_known_failures: bool) -> set[str]:
+    def _get_successful_tasks(self, tasks: List[Task], allow_known_failures: bool) -> set[str]:
         return {
             task.display_name
             for task in tasks
@@ -73,9 +73,10 @@ class EvergreenService:
 
     def _is_task_a_known_failure(self, task) -> bool:
         """
-        A task is a known failure if it has been annotated with an issue or suspected issue that has a BF prefix
-        :param task: the task to check
-        :return: True if the task is a known failure
+        Check if a task is a known failure - annotated with an issue or suspected issue that has a BF prefix.
+
+        :param task: the task to check.
+        :return: True if the task is a known failure.
         """
         annotations = self.evg_api.get_task_annotation(task.task_id)
         for annotation in annotations:

--- a/src/goodbase/services/evg_service.py
+++ b/src/goodbase/services/evg_service.py
@@ -143,6 +143,7 @@ class EvergreenService:
 
         :param evg_version: Evergreen version to check.
         :param build_checks: Build criteria to use.
+        :param allow_known_failures: Whether to allow known failures as passing ones.
         :return: List of build statuses.
         """
         if not evg_version.build_variants_status or len(evg_version.build_variants_status) == 0:

--- a/src/goodbase/services/evg_service.py
+++ b/src/goodbase/services/evg_service.py
@@ -80,12 +80,8 @@ class EvergreenService:
         """
         annotations = self.evg_api.get_task_annotation(task.task_id)
         for annotation in annotations:
-            for issue in annotation.issues:
-                if issue.issue_key[:3] == "BF-":
-                    return True
-            for issue in annotation.suspected_issues:
-                if issue.issue_key[:3] == "BF-":
-                    return True
+            if annotation.issues:
+                return True
         return False
 
     def check_version(

--- a/src/goodbase/services/evg_service.py
+++ b/src/goodbase/services/evg_service.py
@@ -6,7 +6,7 @@ from typing import Dict, List, Optional
 import inject
 import structlog
 import yaml
-from evergreen import Build, EvergreenApi, Version, Task
+from evergreen import Build, EvergreenApi, Task, Version
 from requests.exceptions import HTTPError
 
 from goodbase.build_checker import BuildChecks
@@ -71,7 +71,7 @@ class EvergreenService:
             if task.is_success() or (allow_known_failures and self._is_task_a_known_failure(task))
         }
 
-    def _is_task_a_known_failure(self, task) -> bool:
+    def _is_task_a_known_failure(self, task: Task) -> bool:
         """
         Check if a task is a known failure - annotated with an issue or suspected issue that has a BF prefix.
 

--- a/src/goodbase/services/search_service.py
+++ b/src/goodbase/services/search_service.py
@@ -44,6 +44,7 @@ class SearchService:
 
         :param evg_project: Evergreen project to check.
         :param build_checks: Criteria to enforce.
+        :param allow_known_failures: Whether to allow known failures as passing ones.
         :return: First git revision to match the given criteria if it exists.
         """
         if version_override:
@@ -78,6 +79,7 @@ class SearchService:
 
         :param evg_versions: Evergreen versions to iterate over.
         :param build_checks: Criteria to enforce.
+        :param allow_known_failures: Whether to allow known failures as passing ones.
         :return: First git revision to match the given criteria if it exists.
         """
         start_time = perf_counter()

--- a/tests/goodbase/services/test_search_service.py
+++ b/tests/goodbase/services/test_search_service.py
@@ -47,7 +47,7 @@ def search_service(evg_api, evg_service, options):
 
 class TestFindRevision:
     def test_find_revision_should_use_progressbar_for_plaintext(self, search_service):
-        def assert_progress_bar(bar, _checks):
+        def assert_progress_bar(bar, _checks, _allow_known_failures):
             assert isinstance(bar, ProgressBar)
 
         search_service._find_stable_revision = assert_progress_bar
@@ -58,7 +58,7 @@ class TestFindRevision:
     def test_find_revision_should_not_use_progressbar_for_non_plaintest(
         self, format, search_service, options
     ):
-        def assert_no_progress_bar(bar, _checks):
+        def assert_no_progress_bar(bar, _checks, _allow_known_failures):
             assert not isinstance(bar, ProgressBar)
 
         options.output_format = format
@@ -76,17 +76,17 @@ class TestFindStableRevision:
         revision = search_service._find_stable_revision(version_list, checks)
 
         assert version_list[3].revision == revision
-        evg_service.check_version.assert_any_call(version_list[0], checks)
+        evg_service.check_version.assert_any_call(version_list[0], checks, False)
 
     def test_no_good_revision_should_be_return_none(self, search_service, evg_service):
         version_list = [MagicMock(spec=Version, revision=f"abc_{i}") for i in range(20)]
         checks = [MagicMock(spec=BuildChecks)]
         evg_service.check_version.return_value = False
 
-        revision = search_service._find_stable_revision(version_list, checks)
+        revision = search_service._find_stable_revision(version_list, checks, False)
 
         assert revision is None
-        evg_service.check_version.assert_any_call(version_list[0], checks)
+        evg_service.check_version.assert_any_call(version_list[0], checks, False)
 
     def test_no_good_revision_before_limit_should_be_return_none(
         self, search_service, evg_service, options
@@ -99,4 +99,4 @@ class TestFindStableRevision:
         revision = search_service._find_stable_revision(version_list, checks)
 
         assert revision is None
-        evg_service.check_version.assert_any_call(version_list[0], checks)
+        evg_service.check_version.assert_any_call(version_list[0], checks, False)


### PR DESCRIPTION
<img width="1727" alt="Screenshot 2024-07-25 at 2 27 35 PM" src="https://github.com/user-attachments/assets/1591a37b-9579-49c2-a7ad-d9176b7b7133">

See in image, the version 6501c4f2d1fe071dbddc55af has a failing task that is a known issue.
without the override, no version is found due to the failure. with the override - the version is considered passing