### PR TITLE
Fix misconfigured .optibot file

### DIFF
--- a/.optibot
+++ b/.optibot
@@ -3,10 +3,8 @@
    "reviews": {
       "auto": true,
       "code-generation": true,
-      "auto-approvals": false,
+      "autoApprove": false,
       "include": [
-         "bugs",
-         "security"
       ],
       "exclude": [
       ]


### PR DESCRIPTION
The field should be "autoApprove", not "auto-approvals"